### PR TITLE
Escape HTML chars

### DIFF
--- a/extension/js/devtools.js
+++ b/extension/js/devtools.js
@@ -129,6 +129,8 @@ function handleSocketMessage(event) {
         }
         // append output
         if (currentProject.currentTask && parseInt(pid) === currentProject.currentTask.pid) {
+          var findReplace = [[/&/g, "&amp;"], [/</g, "&lt;"], [/>/g, "&gt;"], [/"/g, "&quot;"]];
+          for (var item in findReplace) output = output.replace(findReplace[item][0], findReplace[item][1]);
           $output.append(output);
           // TODO: fix this
           $outputWrap.scrollTop(99999);


### PR DESCRIPTION
The console should escape/HTML encode special characters. If I have some HTML output in the console, the Dev Tools will actually render this.

I haven't tested this but it should work and it gives you the idea.
